### PR TITLE
Re-enable FT in Refunds 2.1 following release

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/refunds/functional/RefundsApproverJourneyFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/refunds/functional/RefundsApproverJourneyFunctionalTest.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.refunds.functional;
 
 import io.restassured.RestAssured;
 import io.restassured.response.Response;
+import lombok.extern.slf4j.Slf4j;
 import net.serenitybdd.junit.spring.integration.SpringIntegrationSerenityRunner;
 import org.apache.commons.lang3.RandomUtils;
 import org.jetbrains.annotations.NotNull;
@@ -65,6 +66,7 @@ import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.HttpStatus.OK;
 
+@Slf4j
 @ActiveProfiles("functional")
 @RunWith(SpringIntegrationSerenityRunner.class)
 @SpringBootTest
@@ -238,6 +240,7 @@ public class RefundsApproverJourneyFunctionalTest {
 
     @Test
     public void nagative_create_refund_without_service_role() {
+        log.info("DTRJ: Started - nagative_create_refund_without_service_role");
         final String accountNumber = testConfigProperties.existingAccountNumber;
         final CreditAccountPaymentRequest accountPaymentRequest = RefundsFixture
             .pbaPaymentRequestForProbate(
@@ -290,12 +293,17 @@ public class RefundsApproverJourneyFunctionalTest {
         );
 
         // This needs resolving as it's not producing the correct value. As it's a negative test, we can pickup in a bug.
-        //assertThat(refundResponse.getStatusCode()).isEqualTo(BAD_REQUEST.value());
+        log.info("DTRJ: paymentRefundRequest {}", paymentRefundRequest.toString());
+        log.info("DTRJ: SERVICE_TOKEN_PAY_BUBBLE_PAYMENT {}", SERVICE_TOKEN_PAY_BUBBLE_PAYMENT);
+        log.info("DTRJ: Response Status {}", refundResponse.getStatusCode());
+        assertThat(refundResponse.getStatusCode()).isEqualTo(BAD_REQUEST.value());
 
         // delete payment record
         paymentTestService
             .deletePayment(USER_TOKEN_PAYMENTS_REFUND_APPROVER_AND_PAYMENTS_ROLE, SERVICE_TOKEN_PAY_BUBBLE_PAYMENT,
                            paymentReference, testConfigProperties.basePaymentsUrl).then().statusCode(NO_CONTENT.value());
+
+        log.info("DTRJ: Ended - nagative_create_refund_without_service_role");
     }
 
     @Test

--- a/src/functionalTest/java/uk/gov/hmcts/reform/refunds/functional/RefundsApproverJourneyFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/refunds/functional/RefundsApproverJourneyFunctionalTest.java
@@ -296,7 +296,8 @@ public class RefundsApproverJourneyFunctionalTest {
         log.info("DTRJ: paymentRefundRequest {}", paymentRefundRequest.toString());
         log.info("DTRJ: SERVICE_TOKEN_PAY_BUBBLE_PAYMENT {}", SERVICE_TOKEN_PAY_BUBBLE_PAYMENT);
         log.info("DTRJ: Response Status {}", refundResponse.getStatusCode());
-        assertThat(refundResponse.getStatusCode()).isEqualTo(BAD_REQUEST.value());
+        //assertThat(refundResponse.getStatusCode()).isEqualTo(BAD_REQUEST.value());
+        assertThat(refundResponse.getStatusCode()).isEqualTo(OK.value());
 
         // delete payment record
         paymentTestService

--- a/src/functionalTest/java/uk/gov/hmcts/reform/refunds/functional/RefundsApproverJourneyFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/refunds/functional/RefundsApproverJourneyFunctionalTest.java
@@ -65,7 +65,6 @@ import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.HttpStatus.OK;
 
-@Slf4j
 @ActiveProfiles("functional")
 @RunWith(SpringIntegrationSerenityRunner.class)
 @SpringBootTest

--- a/src/functionalTest/java/uk/gov/hmcts/reform/refunds/functional/RefundsApproverJourneyFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/refunds/functional/RefundsApproverJourneyFunctionalTest.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.reform.refunds.functional;
 
 import io.restassured.RestAssured;
 import io.restassured.response.Response;
-import lombok.extern.slf4j.Slf4j;
 import net.serenitybdd.junit.spring.integration.SpringIntegrationSerenityRunner;
 import org.apache.commons.lang3.RandomUtils;
 import org.jetbrains.annotations.NotNull;
@@ -240,7 +239,6 @@ public class RefundsApproverJourneyFunctionalTest {
 
     @Test
     public void nagative_create_refund_without_service_role() {
-        log.info("DTRJ: Started - nagative_create_refund_without_service_role");
         final String accountNumber = testConfigProperties.existingAccountNumber;
         final CreditAccountPaymentRequest accountPaymentRequest = RefundsFixture
             .pbaPaymentRequestForProbate(
@@ -292,19 +290,12 @@ public class RefundsApproverJourneyFunctionalTest {
             testConfigProperties.basePaymentsUrl
         );
 
-        // This needs resolving as it's not producing the correct value. As it's a negative test, we can pickup in a bug.
-        log.info("DTRJ: paymentRefundRequest {}", paymentRefundRequest.toString());
-        log.info("DTRJ: SERVICE_TOKEN_PAY_BUBBLE_PAYMENT {}", SERVICE_TOKEN_PAY_BUBBLE_PAYMENT);
-        log.info("DTRJ: Response Status {}", refundResponse.getStatusCode());
-        //assertThat(refundResponse.getStatusCode()).isEqualTo(BAD_REQUEST.value());
-        assertThat(refundResponse.getStatusCode()).isEqualTo(OK.value());
+        assertThat(refundResponse.getStatusCode()).isEqualTo(BAD_REQUEST.value());
 
         // delete payment record
         paymentTestService
             .deletePayment(USER_TOKEN_PAYMENTS_REFUND_APPROVER_AND_PAYMENTS_ROLE, SERVICE_TOKEN_PAY_BUBBLE_PAYMENT,
                            paymentReference, testConfigProperties.basePaymentsUrl).then().statusCode(NO_CONTENT.value());
-
-        log.info("DTRJ: Ended - nagative_create_refund_without_service_role");
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PAY-6401


### Change description ###
Reenable Refunds functional test which failed before because of a PR pointing issue resulting in the code pointing back to AAT instead of the PR.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
